### PR TITLE
Fix CodeMirror-Portal integration to handle updates

### DIFF
--- a/src/editor/codemirror/CodeMirror.tsx
+++ b/src/editor/codemirror/CodeMirror.tsx
@@ -125,9 +125,25 @@ const CodeMirror = ({
 
   const [portals, setPortals] = useState<PortalContent[]>([]);
   const portalFactory: PortalFactory = useCallback((dom, content) => {
-    const portal = { dom, content };
-    setPortals((portals) => [...portals, portal]);
-    return () => setPortals((portals) => portals.filter((p) => p !== portal));
+    setPortals((portals) => {
+      let found = false;
+      let updated = portals.map((p) => {
+        if (p.dom === dom) {
+          found = true;
+          return {
+            dom,
+            content,
+          };
+        }
+        return p;
+      });
+      if (!found) {
+        updated = [...portals, { dom, content }];
+      }
+      return updated;
+    });
+
+    return () => setPortals((portals) => portals.filter((p) => p.dom !== dom));
   }, []);
 
   useEffect(() => {
@@ -143,7 +159,7 @@ const CodeMirror = ({
           logPastedLineCount(logging, update);
         }
       });
-      
+
       const state = EditorState.create({
         doc: defaultValue,
         extensions: [

--- a/src/editor/codemirror/helper-widgets/setPixelWidget.tsx
+++ b/src/editor/codemirror/helper-widgets/setPixelWidget.tsx
@@ -69,9 +69,9 @@ const MicrobitSinglePixelGrid: React.FC<MicrobitSinglePixelGridProps> = ({
           style={{ marginLeft: "15px", marginTop: "15px", marginBottom: "15px" }}
         >
           {[...Array(5)].map((_, gridY) => (
-            <Box key={y} display="flex">
+            <Box key={gridY} display="flex">
               {[...Array(5)].map((_, gridX) => (
-                <Box key={x} display="flex" mr="0px">
+                <Box key={gridX} display="flex" mr="0px">
                   <Button
                     height="32px"
                     width="30px"

--- a/src/editor/codemirror/helper-widgets/widgetArgParser.tsx
+++ b/src/editor/codemirror/helper-widgets/widgetArgParser.tsx
@@ -36,7 +36,7 @@ export function createWidget(
       break;
     default:
       // No widget implemented for this function
-      console.log("No widget implemented for this function: " + name);
+      // console.log("No widget implemented for this function: " + name);
       return null;
   }
   if (component) {
@@ -60,7 +60,6 @@ function getChildNodes(node: SyntaxNode): SyntaxNode[] {
   let child = node.firstChild?.nextSibling;
   let children = [];
   while (child && child.name !== ")") {
-    console.log(child.name);
     if (child.name !== "," && child.name !== "Comment") children.push(child);
     child = child.nextSibling;
   }


### PR DESCRIPTION
eq should check all props

updateDOM now re-renders the react component - it's called when eq returns false. This maintains state and allows props to change.

We take care to cope with the transition to/from rendering the "inline" case.

CC @martarel @wilsonkooi @AryanRast 

I based this on the widget-eq branch (which I also pushed to) but this version is cleaned up and rebased on main after @AryanRast's recent changes.